### PR TITLE
Fix permission deleting

### DIFF
--- a/KoalaBot/PermissionEngine/Store/RedisStore.cs
+++ b/KoalaBot/PermissionEngine/Store/RedisStore.cs
@@ -75,6 +75,7 @@ namespace KoalaBot.PermissionEngine.Store
 
         public async Task<bool> SaveGroupAsync(Group group)
         {
+            await this.DeleteGroupAsync(group);
             await this.AddGroupAsync(group);
             return true;
         }


### PR DESCRIPTION
The RemovePermission command wasn't functioning despite passing a properly updated Group to SaveGroupAsync. This apparently fixes that, though I'm not sure why.