### PR TITLE
Fix permission system

### DIFF
--- a/KoalaBot/CommandNext/PermissionAttribute.cs
+++ b/KoalaBot/CommandNext/PermissionAttribute.cs
@@ -8,7 +8,7 @@ using System.Threading.Tasks;
 
 namespace KoalaBot.CommandNext
 {
-    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Class, AllowMultiple = false, Inherited = false)]
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = false, Inherited = false)]
     public class PermissionAttribute : CheckBaseAttribute
     {
 

--- a/KoalaBot/Modules/Configuration/ConfigurationModule.cs
+++ b/KoalaBot/Modules/Configuration/ConfigurationModule.cs
@@ -14,7 +14,6 @@ using KoalaBot.CommandNext;
 namespace KoalaBot.Modules.Configuration
 {
     [Group("config")]
-    [Permission("koala.config")]
     public partial class ConfigurationModule : BaseCommandModule
     {
         public Koala Bot { get; }

--- a/KoalaBot/Modules/FunModule.cs
+++ b/KoalaBot/Modules/FunModule.cs
@@ -72,7 +72,7 @@ namespace KoalaBot.Modules
             }
         }
 
-
+        [Permission("koala.fun.emoji")]
         public async Task SetBoosterEmoji(CommandContext ctx)
         {
             if (ctx.Message.Attachments.Count == 0)
@@ -81,6 +81,7 @@ namespace KoalaBot.Modules
             await SetBoosterEmoji(ctx, ctx.Message.Attachments[0].Url);
         }
 
+        [Permission("koala.fun.emoji")]
         public async Task SetBoosterEmoji(CommandContext ctx, string url)
         {
             if (string.IsNullOrEmpty(url))

--- a/KoalaBot/Modules/ModerationModule.cs
+++ b/KoalaBot/Modules/ModerationModule.cs
@@ -17,7 +17,6 @@ using KoalaBot.CommandNext;
 namespace KoalaBot.Modules
 {
     [Group("mod")]
-    [Permission("koala.mod")]
     public class ModerationModule : BaseCommandModule
     {
         public Koala Bot { get; }

--- a/KoalaBot/Modules/Starwatch/AccountModule.cs
+++ b/KoalaBot/Modules/Starwatch/AccountModule.cs
@@ -34,7 +34,6 @@ namespace KoalaBot.Modules.Starwatch
                 this.Logger = new Logger("CMD-SW-ACC", bot.Logger);
             }
 
-
             [Command("enable")]
             [Permission("sw.acc.enable")]
             [Description("Enables an account")]
@@ -49,6 +48,7 @@ namespace KoalaBot.Modules.Starwatch
                 //Build the response                
                 await ctx.ReplyReactionAsync(true);
             }
+
             [Command("disable")]
             [Permission("sw.acc.disable")]
             [Description("Disables an account")]

--- a/KoalaBot/Modules/Starwatch/StarwatchModule.cs
+++ b/KoalaBot/Modules/Starwatch/StarwatchModule.cs
@@ -20,7 +20,6 @@ using KoalaBot.Starwatch.Exceptions;
 namespace KoalaBot.Modules.Starwatch
 {
     [Group("starwatch"), Aliases("sw", "s")]
-    [Permission("sw")]
     public partial class StarwatchModule : BaseCommandModule
     {
         public Koala Bot { get; }
@@ -138,6 +137,7 @@ namespace KoalaBot.Modules.Starwatch
         }
 
         [Command("search")]
+        [Permission("sw.search")]
         public async Task SearchSessions(CommandContext ctx,
             [Description("Account name to search")]     string account = null,
             [Description("Character name to search")]   string character = null,

--- a/KoalaBot/Modules/Starwatch/WorldModule.cs
+++ b/KoalaBot/Modules/Starwatch/WorldModule.cs
@@ -42,6 +42,7 @@ namespace KoalaBot.Modules.Starwatch
 
             [Command("alias")]
             [Description("Sets the specified alias.")]
+            [Permission("sw.world.alias")]
             public async Task SetAlias(CommandContext ctx, string alias, World world = null)
             {
                 //World is null, so delete the alias

--- a/KoalaBot/Modules/TagModule.cs
+++ b/KoalaBot/Modules/TagModule.cs
@@ -14,7 +14,6 @@ using KoalaBot.CommandNext;
 namespace KoalaBot.Modules
 {
     [Group("tag")]
-    [Permission("koala.tag")]
     public class TagModule : BaseCommandModule
     {
         public Koala Bot { get; }
@@ -102,6 +101,7 @@ namespace KoalaBot.Modules
         }
 
         /// <summary>Fetches a tag</summary>
+        [Permission("koala.tag.view")]
         public async Task<Tag> GetTagAsync(DiscordGuild guild, string name)
         {
             name = name.ToLowerInvariant();     //First thing is we will lower the name. All names will be case insensitive.
@@ -111,9 +111,11 @@ namespace KoalaBot.Modules
         }
 
         /// <summary>Edits the tag</summary>
+        [Permission("koala.tag.edit")]
         public async Task EditTagAsync(DiscordGuild guild, Tag tag, string content) => await Redis.StoreStringAsync(Namespace.Combine(guild.Id, "tags", tag.Name), Tag.KEY_CONTENT, content);
 
         /// <summary>Creates a tag</summary>
+        [Permission("koala.tag.create")]
         public async Task<Tag> CreateTagAsync(DiscordGuild guild, DiscordUser owner, string name, string content)
         {
             Tag tag = new Tag()
@@ -133,6 +135,7 @@ namespace KoalaBot.Modules
         }
 
         /// <summary>Transfers a tag a tag</summary>
+        [Permission("koala.tag.transfer")]
         public async Task TransferTagAsync(DiscordGuild guild, DiscordUser newOwner, Tag tag)
         {
             var transaction = Redis.CreateTransaction();
@@ -143,6 +146,7 @@ namespace KoalaBot.Modules
         }
 
         /// <summary>Removes a tag</summary>
+        [Permission("koala.tag.remove")]
         public async Task RemoveTagAsync(DiscordGuild guild, Tag tag)
         {
             var transaction = Redis.CreateTransaction();
@@ -151,8 +155,6 @@ namespace KoalaBot.Modules
             _ = transaction.RemoveHashSetAsync(Namespace.Combine(guild.Id, tag.Owner, "tags"), tag.Name);   //Remove tag
             await transaction.ExecuteAsync();
         }
-
-
     }
 
     public class Tag


### PR DESCRIPTION
@Lachee I'm not sure if you ran into this or I just don't understand why this works the way it does but:

```cs
[Permission("sw")]
[Group("sw")]
public class StarwatchModule
{
    [Permission("sw.test")]
    [Command("test")]
    public async Task DoSomething () { }
}
```

If someone tries to use \sw test it only checks for:
- koala.execute.some channel id
- sw.some channel id
- sw

and never asks for sw.test. If I remove the permission attribute from the class, everything starts working properly.