### PR TITLE
Add account commands

### DIFF
--- a/KoalaBot/Extensions/ReplyExtensions.cs
+++ b/KoalaBot/Extensions/ReplyExtensions.cs
@@ -104,6 +104,18 @@ namespace KoalaBot.Extensions
                 .WithColor(EmbedExtensions.ErrorColour));
 
         /// <summary>
+        /// Deletes the sender's message before replying.
+        /// </summary>
+        public static async Task ReplyDeleteAsync (this CommandContext ctx, string message)
+        {
+            var dChannel = ctx.Channel;
+            var dMessage = ctx.Message;
+
+            await dMessage.DeleteAsync();
+            await dChannel.SendMessageAsync(message);
+        }
+
+        /// <summary>
         /// Replys with a paginated message
         /// </summary>
         /// <param name="c"></param>

--- a/KoalaBot/Extensions/StringExtensions.cs
+++ b/KoalaBot/Extensions/StringExtensions.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace KoalaBot.Extensions
+{
+    public static class StringExtensions
+    {
+        private const string YES = "yes";
+        private const string TRUE = "true";
+        private const string NO = "no";
+        private const string FALSE = "false";
+
+        /// <summary>
+        /// Converts a command argument's <see cref="string"/> to a <see cref="bool"/>.
+        /// </summary>
+        /// <param name="_default">Fallback if the string could not be converted.</param>
+        /// <exception cref="ArgumentException">When no default is provided and the string doesn't match any cases.</exception>
+        public static void ToCommandBool(this string str, out bool output, bool? _default = null)
+        {
+            if (str.Equals(YES,  StringComparison.InvariantCultureIgnoreCase) ||
+                str.Equals(TRUE, StringComparison.InvariantCultureIgnoreCase))
+            {
+                output = true;
+                return;
+            }
+
+            if (str.Equals(NO,    StringComparison.InvariantCultureIgnoreCase) ||
+                str.Equals(FALSE, StringComparison.InvariantCultureIgnoreCase))
+            {
+                output = false;
+                return;
+            }
+
+            if (_default is null)
+            {
+                throw new ArgumentException(nameof(str), "String could not be converted to a bool.");
+            }
+
+            output = _default.Value;
+        }
+    }
+}

--- a/KoalaBot/Modules/Starwatch/AccountModule.cs
+++ b/KoalaBot/Modules/Starwatch/AccountModule.cs
@@ -10,6 +10,7 @@ using KoalaBot.Redis;
 using KoalaBot.Starwatch;
 using KoalaBot.Starwatch.Entities;
 using KoalaBot.Starwatch.Exceptions;
+using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.Text;
@@ -64,6 +65,157 @@ namespace KoalaBot.Modules.Starwatch
                 await ctx.ReplyReactionAsync(true);
             }
 
+            [Command("create")]
+            [Permission("sw.acc.create")]
+            [Description("Creates a normal account")]
+            public async Task CreateAccount(CommandContext ctx,
+                [Description("The username")] string username,
+                [Description("The password")] string password,
+                [Description("Make admin?")] string makeAdmin = "no"
+            )
+            {
+                await ctx.ReplyWorkingAsync();
+
+                makeAdmin.ToCommandBool(out bool bMakeAdmin, false);
+                if (bMakeAdmin)
+                {
+                    bool hasPerms = await ctx.Member.HasPermissionAsync("sw.acc.createadmin");
+                    if (!hasPerms)
+                    {
+                        Logger.LogError($"{ctx.User.Username}#{ctx.User.Discriminator} tried to create an admin account with no permission.");
+                        await ctx.ReplyDeleteAsync($"{ctx.User.Mention}: You're missing the ``sw.acc.createadmin`` permission.");
+                        return;
+                    }
+                }
+
+                Account account = new Account
+                {
+                    IsActive = true,
+                    IsAdmin = bMakeAdmin,
+                    Name = username,
+                    Password = password
+                };
+
+                try
+                {
+                    var resp = await Starwatch.CreateAccountAsync(account);
+
+                    // Success
+                    if (resp.Status == RestStatus.OK)
+                        await ctx.ReplyDeleteAsync($"{ctx.User.Mention} created an account '{username}'");
+
+                    // User likely already exists.
+                    else if (resp.Status == RestStatus.BadRequest && !(resp.Message is null))
+                        await ctx.ReplyDeleteAsync($"{ctx.User.Mention}: {resp.Message}");
+
+                    // Something wrong happened, maybe SSL?
+                    else if (!(resp.Message is null))
+                        await ctx.ReplyDeleteAsync($"{ctx.User.Mention}: Could not perform that action: {resp.Status.ToString()} - {resp.Message}");
+
+                    // Something pretty wrong happened.
+                    else
+                        await ctx.ReplyDeleteAsync($"{ctx.User.Mention}: Could not perform that action: {resp.Status.ToString()}");
+                }
+                catch (Exception ex)
+                {
+                    Logger.LogError(ex, $"Caused by: {ctx.User.Mention} - Exception occurred with creating an account.");
+                    throw ex;
+                }
+            }
+
+            [Command("delete")]
+            [Permission("sw.acc.delete")]
+            [Description("Deletes an account")]
+            public async Task DeleteAccount(CommandContext ctx,
+                [Description("The username")] string username)
+            {
+                await ctx.ReplyWorkingAsync();
+
+                try
+                {
+                    var resp = await Starwatch.DeleteAccountAsync(username);
+
+                    if (resp.Status == RestStatus.OK)
+                        await ctx.ReplyAsync($"{ctx.User.Mention} deleted account '{username}'");
+
+                    else if (!(resp.Message is null))
+                        await ctx.ReplyAsync($"{ctx.User.Mention}: Could not delete the user '{username}': {resp.Status.ToString()} - {resp.Message}");
+
+                    else
+                        await ctx.ReplyAsync($"{ctx.User.Mention}: Could not delete the user '{username}': {resp.Status.ToString()}");
+                }
+                catch (Exception ex)
+                {
+                    Logger.LogError(ex, $"Caused by: {ctx.User.Mention} - Exception occurred with deleting an account.");
+                    throw ex;
+                }
+            }
+
+            [Command("promote")]
+            [Permission("sw.acc.promote")]
+            [Description("Promotes a user to admin.")]
+            public async Task PromoteAccount(CommandContext ctx,
+                [Description("The username")] string username)
+            {
+                await ctx.ReplyWorkingAsync();
+
+                Account account = new Account
+                {
+                    IsAdmin = true
+                };
+
+                try
+                {
+                    var resp = await Starwatch.UpdateAccountAsync(username, account);
+
+                    if (resp.Status == RestStatus.OK)
+                        await ctx.ReplyAsync($"{ctx.User.Mention} promoted account '{username}'");
+
+                    else if (!(resp.Message is null))
+                        await ctx.ReplyAsync($"{ctx.User.Mention}: Could not promote the user '{username}': {resp.Status.ToString()} - {resp.Message}");
+
+                    else
+                        await ctx.ReplyAsync($"{ctx.User.Mention}: Could not promote the user '{username}': {resp.Status.ToString()}");
+                }
+                catch (Exception ex)
+                {
+                    Logger.LogError(ex, $"Caused by: {ctx.User.Mention} - Exception occurred with promoting an account.");
+                    throw ex;
+                }
+            }
+
+            [Command("demote")]
+            [Permission("sw.acc.demote")]
+            [Description("Demotes a user to normal.")]
+            public async Task DemoteAccount(CommandContext ctx,
+                [Description("The username")] string username)
+            {
+                await ctx.ReplyWorkingAsync();
+
+                Account account = new Account
+                {
+                    IsAdmin = false
+                };
+
+                try
+                {
+                    var resp = await Starwatch.UpdateAccountAsync(username, account);
+
+                    if (resp.Status == RestStatus.OK)
+                        await ctx.ReplyAsync($"{ctx.User.Mention} demoted account '{username}'");
+
+                    else if (!(resp.Message is null))
+                        await ctx.ReplyAsync($"{ctx.User.Mention}: Could not demote the user '{username}': {resp.Status.ToString()} - {resp.Message}");
+
+                    else
+                        await ctx.ReplyAsync($"{ctx.User.Mention}: Could not demote the user '{username}': {resp.Status.ToString()}");
+                }
+                catch (Exception ex)
+                {
+                    Logger.LogError(ex, $"Caused by: {ctx.User.Mention} - Exception occurred with demoting an account.");
+                    throw ex;
+                }
+            }
         }
     }
 }

--- a/KoalaBot/Starwatch/StarwatchClient.cs
+++ b/KoalaBot/Starwatch/StarwatchClient.cs
@@ -187,6 +187,14 @@ namespace KoalaBot.Starwatch
         #region Account
         public async Task<Response<Account>> GetAccountAsync(string name) => await GetRequestAsync<Account>($"/account/{name}");
 
+        public async Task<Response<Account>> CreateAccountAsync(Account account)
+        {
+            if (account is null)
+                throw new ArgumentNullException(nameof(account));
+
+            return await PostRequestAsync<Account>($"/account", payload: account);
+        }
+
         public async Task<Response<Account>> UpdateAccountAsync(string name, Account account) => await PutRequestAsync<Account>($"/account/{name}", payload: account);
 
         public async Task<Response<bool>> DeleteAccountAsync(string name) => await DeleteRequestAsync<bool>($"/account/{name}");

--- a/KoalaBot/Starwatch/StarwatchClient.cs
+++ b/KoalaBot/Starwatch/StarwatchClient.cs
@@ -285,9 +285,6 @@ namespace KoalaBot.Starwatch
             //Read the json
             string json = await response.Content.ReadAsStringAsync();
 
-            if (response.StatusCode == System.Net.HttpStatusCode.BadRequest)
-                throw new HttpRequestException("Bad Request");
-
             //Return the json object deserialized.
             var res = JsonConvert.DeserializeObject<Response<JToken>>(json);
             if (res == null) throw new Exception("Failed to get any response from the server. Got: " + json);
@@ -305,9 +302,6 @@ namespace KoalaBot.Starwatch
 
                 case RestStatus.TooManyRequests:
                     throw new RestRateLimitException(new Response<RateLimit>(res));
-
-                case RestStatus.InternalError:
-                    throw new RestResponseException(res);
 
                 //Return the response. Everything else can be handled.
                 default:


### PR DESCRIPTION
Adds the following commands:
- ``sw.acc.create`` \sw acc create <username> <password> [makeAdmin] - If makeAdmin is "yes" or "true", also requires ``sw.acc.createadmin``
- ``sw.acc.promote`` \sw acc promote <username>
- ``sw.acc.demote`` \sw acc demote <username>

Additionally no longer throws exceptions for BadRequest or InternalError to allow for commands to handle it on its own while still receiving the response object.