### PR TITLE
Fix \sw reload command

### DIFF
--- a/KoalaBot/Starwatch/StarwatchClient.cs
+++ b/KoalaBot/Starwatch/StarwatchClient.cs
@@ -57,7 +57,11 @@ namespace KoalaBot.Starwatch
         /// <returns></returns>
         public async Task<RestResponse> ReloadAsync(bool wait)
         {
-            return await PutRequestAsync<object>("/server", new Dictionary<string, object>() { ["async"] = !wait });
+            return await PutRequestAsync<object>(
+                "/server", 
+                new Dictionary<string, object>() { ["async"] = !wait, ["reload"] = true }, 
+                new Dictionary<string, object>() { }
+            );
         }
 
         /// <summary>


### PR DESCRIPTION
``null`` can't be cast to ``Payload`` (since it is a ``struct``), and since ``[PUT] /server`` tries to cast ``object payload`` to ``Payload``, it throws an exception before finishing.