### PR TITLE
Add kick module

### DIFF
--- a/KoalaBot/Modules/Starwatch/KickModule.cs
+++ b/KoalaBot/Modules/Starwatch/KickModule.cs
@@ -1,0 +1,191 @@
+﻿using DSharpPlus.CommandsNext;
+using DSharpPlus.CommandsNext.Attributes;
+using KoalaBot.Extensions;
+using KoalaBot.Logging;
+using KoalaBot.Redis;
+using KoalaBot.Starwatch;
+using KoalaBot.Starwatch.Entities;
+using KoalaBot.Starwatch.Responses;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace KoalaBot.Modules.Starwatch
+{
+    public partial class StarwatchModule
+    {
+        [Group("kick")]
+        public partial class KickModule : BaseCommandModule
+        {
+            public Koala Bot { get; }
+            public IRedisClient Redis => Bot.Redis;
+            public Logger Logger { get; }
+            public StarwatchClient Starwatch => Bot.Starwatch;
+
+            public KickModule(Koala bot)
+            {
+                this.Bot = bot;
+                this.Logger = new Logger("CMD-SW-KICK", bot.Logger);
+            }
+
+            [Command("cid")]
+            [Aliases("$")]
+            public async Task KickCid(
+                CommandContext ctx,
+                [Description("CID to kick")] int cid,
+                [Description("Reason")] string reason = null,
+                [Description("Duration")] int? duration = null
+            )
+            {
+                await ctx.ReplyWorkingAsync();
+
+                Player p = new Player
+                {
+                    Connection = cid
+                };
+
+                var resp = await Starwatch.KickPlayerAsync(p, reason, duration);
+
+                if (resp.Status != RestStatus.OK)
+                {
+                    await ctx.ReplyAsync($"{ctx.User.Mention}: Failed to kick CID '{cid}' - {resp.Message}");
+                    return;
+                }
+
+                await ctx.ReplyAsync($"{ctx.User.Mention}: Kicked {resp.Payload.SuccessfulKicks} player(s).");
+            }
+
+            [Command("username"), Aliases("user", "name")]
+            public async Task KickUsername(
+                CommandContext ctx,
+                [Description("Username to kick")] string username,
+                [Description("Reason")] string reason = null,
+                [Description("Duration")] int? duration = null
+            )
+            {
+                await ctx.ReplyWorkingAsync();
+
+                Player p = new Player
+                {
+                    Username = username
+                };
+
+                var resp = await Starwatch.KickPlayerAsync(p, reason, duration);
+
+                if (resp.Status != RestStatus.OK)
+                {
+                    await ctx.ReplyAsync($"{ctx.User.Mention}: Failed to kick Username '{username}' - {resp.Message}");
+                    return;
+                }
+
+                await ctx.ReplyAsync($"{ctx.User.Mention}: Kicked {resp.Payload.SuccessfulKicks} player(s).");
+            }
+
+
+            [Command("nickname"), Aliases("nick")]
+            public async Task KickNickname(
+                CommandContext ctx,
+                [Description("Nickname to kick")] string nickname,
+                [Description("Reason")] string reason = null,
+                [Description("Duration")] int? duration = null
+            )
+            {
+                await ctx.ReplyWorkingAsync();
+
+                Player p = new Player
+                {
+                    Nickname = nickname
+                };
+
+                var resp = await Starwatch.KickPlayerAsync(p, reason, duration);
+
+                if (resp.Status != RestStatus.OK)
+                {
+                    await ctx.ReplyAsync($"{ctx.User.Mention}: Failed to kick Nickname '{nickname}' - {resp.Message}");
+                    return;
+                }
+
+                await ctx.ReplyAsync($"{ctx.User.Mention}: Kicked {resp.Payload.SuccessfulKicks} player(s).");
+            }
+
+            [Command("uuid")]
+            public async Task KickUuid(
+                CommandContext ctx,
+                [Description("UUID to kick")] string uuid,
+                [Description("Reason")] string reason = null,
+                [Description("Duration")] int? duration = null
+            )
+            {
+                await ctx.ReplyWorkingAsync();
+
+                Player p = new Player
+                {
+                    UUID = uuid
+                };
+
+                var resp = await Starwatch.KickPlayerAsync(p, reason, duration);
+
+                if (resp.Status != RestStatus.OK)
+                {
+                    await ctx.ReplyAsync($"{ctx.User.Mention}: Failed to kick UUID '{uuid}' - {resp.Message}");
+                    return;
+                }
+
+                await ctx.ReplyAsync($"{ctx.User.Mention}: Kicked {resp.Payload.SuccessfulKicks} player(s).");
+            }
+
+            [Command("account"), Aliases("acc")]
+            public async Task KickAccount(
+                CommandContext ctx,
+                [Description("Account to kick")] string account,
+                [Description("Reason")] string reason = null,
+                [Description("Duration")] int? duration = null
+            )
+            {
+                await ctx.ReplyWorkingAsync();
+
+                Player p = new Player
+                {
+                    AccountName = account
+                };
+
+                var resp = await Starwatch.KickPlayerAsync(p, reason, duration);
+
+                if (resp.Status != RestStatus.OK)
+                {
+                    await ctx.ReplyAsync($"{ctx.User.Mention}: Failed to kick Account '{account}' - {resp.Message}");
+                    return;
+                }
+
+                await ctx.ReplyAsync($"{ctx.User.Mention}: Kicked {resp.Payload.SuccessfulKicks} player(s).");
+            }
+
+            [Command("ip")]
+            public async Task KickIp (
+                CommandContext ctx, 
+                [Description("IP to kick")] string ip,
+                [Description("Reason")] string reason = null,
+                [Description("Duration")] int? duration = null
+            )
+            {
+                await ctx.ReplyWorkingAsync();
+
+                Player p = new Player
+                {
+                    IP = ip
+                };
+
+                var resp = await Starwatch.KickPlayerAsync(p, reason, duration);
+
+                if (resp.Status != RestStatus.OK)
+                {
+                    await ctx.ReplyAsync($"{ctx.User.Mention}: Failed to kick IP '{ip}' - {resp.Message}");
+                    return;
+                }
+
+                await ctx.ReplyAsync($"{ctx.User.Mention}: Kicked {resp.Payload.SuccessfulKicks} player(s).");
+            }
+        }
+    }
+}

--- a/KoalaBot/Starwatch/Entities/Player.cs
+++ b/KoalaBot/Starwatch/Entities/Player.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Web;
+using System.Linq;
+
+namespace KoalaBot.Starwatch.Entities
+{
+    public class Player
+    {
+        public int? Connection { get; set; } = null;
+        public string Username { get; set; } = null;
+        public string Nickname { get; set; } = null;
+        public string AccountName { get; set; } = null;
+        public string UUID { get; set; } = null;
+        public string IP { get; set; } = null;
+
+        public string EncodeAsParameters()
+        {
+            Dictionary<string, string> parameters = new Dictionary<string, string>();
+
+            if (!(Connection is null))
+                parameters.Add("cid", Connection.ToString());
+
+            if (!(Username is null))
+                parameters.Add("username", Username);
+
+            if (!(Nickname is null))
+                parameters.Add("nickname", Nickname);
+
+            if (!(AccountName is null))
+                parameters.Add("account", AccountName);
+
+            if (!(UUID is null))
+                parameters.Add("uuid", UUID);
+
+            if (!(IP is null))
+                parameters.Add("ip", IP);
+
+            if (parameters.Count == 0)
+                return "";
+
+            return string.Join("&", parameters.Select(kvp => $"{kvp.Key}={HttpUtility.UrlEncode(kvp.Value)}"));
+        }
+    }
+}

--- a/KoalaBot/Starwatch/Responses/PlayerKickResponse.cs
+++ b/KoalaBot/Starwatch/Responses/PlayerKickResponse.cs
@@ -1,0 +1,14 @@
+﻿using KoalaBot.Starwatch.Entities;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace KoalaBot.Starwatch.Responses
+{
+    public class PlayerKickResponse
+    {
+        public List<Player> Players { get; set; } = new List<Player>();
+        public int SuccessfulKicks { get; set; } = 0;
+        public int FailedKicks { get; set; } = 0;
+    }
+}

--- a/KoalaBot/Starwatch/StarwatchClient.cs
+++ b/KoalaBot/Starwatch/StarwatchClient.cs
@@ -10,6 +10,7 @@ using System.Net.Http;
 using System.Text;
 using System.Threading.Tasks;
 using System.Web;
+using KoalaBot.Starwatch.Responses;
 
 namespace KoalaBot.Starwatch
 {
@@ -202,6 +203,21 @@ namespace KoalaBot.Starwatch
         public async Task<Response<Account>> UpdateAccountAsync(string name, Account account) => await PutRequestAsync<Account>($"/account/{name}", payload: account);
 
         public async Task<Response<bool>> DeleteAccountAsync(string name) => await DeleteRequestAsync<bool>($"/account/{name}");
+
+        public async Task<Response<PlayerKickResponse>> KickPlayerAsync(Player player, string reason = null, int? duration = null)
+        {
+            string reasonParam = string.Empty;
+            string durationParam = string.Empty;
+
+            if (!(reason is null))
+                reasonParam = $"&reason={HttpUtility.UrlEncode(reason)}";
+
+            if (!(duration is null))
+                durationParam = $"&duration={duration}";
+
+            string url = $"/player/kick?{player.EncodeAsParameters()}{reasonParam}{durationParam}";
+            return await DeleteRequestAsync<PlayerKickResponse>(url);
+        }
 
         #endregion
 


### PR DESCRIPTION
Uses [Starwatch's new kick route](https://github.com/Lachee/starwatch/pull/18) to kick players who match specific queries.

### Commands
- **\sw kick cid -cid- [reason = "Disconnected due to inactivity"] [duration = null]**
Kicks all players with the connection ID provided.
Alias: ``$``

- **\sw kick username -username- [reason = "Disconnected due to inactivity"] [duration = null]**
Kicks all players with the player name provided.
Aliases: ``user``, ``name``

- **\sw kick uuid -uuid- [reason = "Disconnected due to inactivity"] [duration = null]**
Kicks all players with the UUID provided.

- **\sw kick ip -ip- [reason = "Disconnected due to inactivity"] [duration = null]**
Kicks all players with the IP address provided.

- **\sw kick nickname -nickname- [reason = "Disconnected due to inactivity"] [duration = null]**
Kicks all players with the nickname provided.
Alias: ``nick``

- **\sw kick account -account- [reason = "Disconnected due to inactivity"] [duration = null]**
Kicks all players with the account name provided.
Alias: ``acc``