### PR TITLE
Add announcement module

### DIFF
--- a/KoalaBot/Modules/Starwatch/AnnouncementModule.cs
+++ b/KoalaBot/Modules/Starwatch/AnnouncementModule.cs
@@ -48,7 +48,7 @@ namespace KoalaBot.Modules.Starwatch
                     throw new RestResponseException(response);
 
                 //Build the response                
-                await ctx.ReplyAsync("Deleted it.");
+                await ctx.ReplyAsync($"{ctx.User.Mention}: Deleted announcement #{id}");
             }
 
             [Command("add"), Aliases("+")]
@@ -67,7 +67,11 @@ namespace KoalaBot.Modules.Starwatch
                     throw new RestResponseException(response);
 
                 //Build the response
-                await ctx.ReplyAsync("Added it.");
+                await ctx.ReplyAsync(
+                    $"{ctx.User.Mention}: Added new announcement." +
+                    $"\n**Message**: '{message}'" +
+                    $"\n**Enabled**: '{enabled.ToString().ToLowerInvariant()}'" +
+                    $"\n**Interval**: '{interval}' seconds");
             }
 
             [Command("enable")]
@@ -174,7 +178,7 @@ namespace KoalaBot.Modules.Starwatch
                 //404, the world doesn't exist
                 if (response.Status == RestStatus.ResourceNotFound)
                 {
-                    await ctx.ReplyAsync(id + " is not a valid announcement.");
+                    await ctx.ReplyAsync($"{ctx.User.Mention}: Announcement #{id} doesn't exist.");
                     return;
                 }
 

--- a/KoalaBot/Modules/Starwatch/AnnouncementModule.cs
+++ b/KoalaBot/Modules/Starwatch/AnnouncementModule.cs
@@ -1,0 +1,111 @@
+﻿using DSharpPlus.CommandsNext;
+using DSharpPlus.CommandsNext.Attributes;
+using DSharpPlus.CommandsNext.Exceptions;
+using DSharpPlus.Entities;
+using KoalaBot.CommandNext;
+using KoalaBot.Exceptions;
+using KoalaBot.Extensions;
+using KoalaBot.Logging;
+using KoalaBot.Redis;
+using KoalaBot.Starwatch;
+using KoalaBot.Starwatch.Entities;
+using KoalaBot.Starwatch.Exceptions;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace KoalaBot.Modules.Starwatch
+{
+    public partial class StarwatchModule
+    {
+        [Group("announcement"), Aliases("an")]
+        [Description("Announcements")]
+        public partial class AnnouncementModule : BaseCommandModule
+        {
+            public Koala Bot { get; }
+            public IRedisClient Redis => Bot.Redis;
+            public Logger Logger { get; }
+            public StarwatchClient Starwatch => Bot.Starwatch;
+
+            public AnnouncementModule(Koala bot)
+            {
+                this.Bot = bot;
+                this.Logger = new Logger("CMD-SW-ANNOUNCE", bot.Logger);
+            }
+
+
+            [Command("delete"), Aliases("-", "remove")]
+            [Permission("sw.announce.delete")]
+            [Description("Deletes an announcement")]
+            public async Task DeleteAnnouncement(CommandContext ctx, [Description("The id of the announmcement")] long id)
+            {
+
+                await ctx.ReplyWorkingAsync();
+                var response = await Starwatch.DeleteAnnouncementAsync(id);
+
+                if (response.Status != RestStatus.OK)
+                    throw new RestResponseException(response);
+
+                //Build the response                
+                await ctx.ReplyAsync("Deleted it.");
+            }
+
+            [Command("add"), Aliases("+")]
+            [Permission("sw.announce.add")]
+            [Description("Adds an announcement")]
+            public async Task AddAnnouncement(CommandContext ctx,
+                [Description("The message to RCON.")] string message,
+                [Description("Whether to enable the announcement or not.")] bool enabled,
+                [Description("Interval in seconds.")] double interval)
+            {
+
+                await ctx.ReplyWorkingAsync();
+                var response = await Starwatch.PostAnnouncementAsync(message, enabled, interval);
+
+                if (response.Status != RestStatus.OK)
+                    throw new RestResponseException(response);
+
+                //Build the response
+                await ctx.ReplyAsync("Added it.");
+            }
+
+            [Command("get")]
+            [Permission("sw.announcement.view")]
+            [Description("Checks an announcement")]
+            public async Task BanPlayer(CommandContext ctx,
+                [Description("The id of the announcement")] long id)
+            {
+                //Fetch the response
+                await ctx.ReplyWorkingAsync();
+
+                //res
+                var response = await Starwatch.GetAnnouncementAsync(id);
+
+                //404, the world doesn't exist
+                if (response.Status == RestStatus.ResourceNotFound)
+                {
+                    await ctx.ReplyAsync(id + " is not a valid announcement.");
+                    return;
+                }
+
+                //Something else, throw an exception
+                if (response.Status != RestStatus.OK)
+                    throw new RestResponseException(response);
+
+                //Build the response                
+                await ctx.ReplyAsync(embed: BuildAnnouncementEmbed(response.Payload));
+            }
+
+            private DiscordEmbed BuildAnnouncementEmbed(Announcement announcement)
+            {
+                DiscordEmbedBuilder builder = new DiscordEmbedBuilder();
+                builder.WithTitle($"Announcement")
+                    .AddField("Message", announcement.Message)
+                    .AddField("Enabled", announcement.Enabled.ToString())
+                    .AddField("Interval (seconds)", announcement.Interval.ToString());
+                return builder.Build();
+            }
+        }
+    }
+}

--- a/KoalaBot/Modules/Starwatch/AnnouncementModule.cs
+++ b/KoalaBot/Modules/Starwatch/AnnouncementModule.cs
@@ -163,7 +163,7 @@ namespace KoalaBot.Modules.Starwatch
                 await ctx.ReplyAsync($"{ctx.User.Mention}: Set announcement interval for announcement #{id}");
             }
 
-            [Command("get")]
+            [Command("view"), Aliases("get")]
             [Permission("sw.announcement.view")]
             [Description("Checks an announcement")]
             public async Task ViewAnnouncement(CommandContext ctx,

--- a/KoalaBot/Modules/Starwatch/AnnouncementModule.cs
+++ b/KoalaBot/Modules/Starwatch/AnnouncementModule.cs
@@ -77,7 +77,7 @@ namespace KoalaBot.Modules.Starwatch
             [Command("enable")]
             [Permission("sw.announce.enable")]
             [Description("Enables an announcement.")]
-            public async Task Task(CommandContext ctx,
+            public async Task EnableAnnouncement(CommandContext ctx,
                 [Description("The ID of the announcement")] int id)
             {
                 await ctx.ReplyWorkingAsync();
@@ -143,9 +143,9 @@ namespace KoalaBot.Modules.Starwatch
             [Command("setinterval"), Aliases("setint", "timer", "settimer")]
             [Permission("sw.announce.setinterval")]
             [Description("Sets an announcement's timer interval")]
-            public async Task SetAnnouncementMessage(CommandContext ctx,
+            public async Task SetAnnouncementInterval(CommandContext ctx,
                 [Description("The ID of the announcement")] int id,
-                [Description("The interval of the announcement in seconds")] int interval)
+                [Description("The interval of the announcement in seconds")] double interval)
             {
                 await ctx.ReplyWorkingAsync();
 
@@ -166,7 +166,7 @@ namespace KoalaBot.Modules.Starwatch
             [Command("get")]
             [Permission("sw.announcement.view")]
             [Description("Checks an announcement")]
-            public async Task BanPlayer(CommandContext ctx,
+            public async Task ViewAnnouncement(CommandContext ctx,
                 [Description("The id of the announcement")] long id)
             {
                 //Fetch the response

--- a/KoalaBot/Modules/Starwatch/AnnouncementModule.cs
+++ b/KoalaBot/Modules/Starwatch/AnnouncementModule.cs
@@ -113,6 +113,52 @@ namespace KoalaBot.Modules.Starwatch
                 await ctx.ReplyAsync($"{ctx.User.Mention}: Disabled announcement #{id}");
             }
 
+            [Command("setmessage"), Aliases("setmsg")]
+            [Permission("sw.announce.setmessage")]
+            [Description("Sets an announcement's message")]
+            public async Task SetAnnouncementMessage(CommandContext ctx,
+                [Description("The ID of the announcement")] int id,
+                [Description("The message of the announcement")] string message)
+            {
+                await ctx.ReplyWorkingAsync();
+
+                AnnouncementPatch patch = new AnnouncementPatch
+                {
+                    Message = message,
+                    Id = id
+                };
+
+                var response = await Starwatch.PutAnnouncementAsync(patch);
+
+                if (response.Status != RestStatus.OK)
+                    throw new RestResponseException(response);
+
+                await ctx.ReplyAsync($"{ctx.User.Mention}: Set announcement message for announcement #{id}");
+            }
+
+            [Command("setinterval"), Aliases("setint", "timer", "settimer")]
+            [Permission("sw.announce.setinterval")]
+            [Description("Sets an announcement's timer interval")]
+            public async Task SetAnnouncementMessage(CommandContext ctx,
+                [Description("The ID of the announcement")] int id,
+                [Description("The interval of the announcement in seconds")] int interval)
+            {
+                await ctx.ReplyWorkingAsync();
+
+                AnnouncementPatch patch = new AnnouncementPatch
+                {
+                    Interval = interval,
+                    Id = id
+                };
+
+                var response = await Starwatch.PutAnnouncementAsync(patch);
+
+                if (response.Status != RestStatus.OK)
+                    throw new RestResponseException(response);
+
+                await ctx.ReplyAsync($"{ctx.User.Mention}: Set announcement interval for announcement #{id}");
+            }
+
             [Command("get")]
             [Permission("sw.announcement.view")]
             [Description("Checks an announcement")]

--- a/KoalaBot/Modules/Starwatch/AnnouncementModule.cs
+++ b/KoalaBot/Modules/Starwatch/AnnouncementModule.cs
@@ -70,6 +70,49 @@ namespace KoalaBot.Modules.Starwatch
                 await ctx.ReplyAsync("Added it.");
             }
 
+            [Command("enable")]
+            [Permission("sw.announce.enable")]
+            [Description("Enables an announcement.")]
+            public async Task Task(CommandContext ctx,
+                [Description("The ID of the announcement")] int id)
+            {
+                await ctx.ReplyWorkingAsync();
+
+                AnnouncementPatch patch = new AnnouncementPatch
+                {
+                    Enabled = true
+                };
+
+                var response = await Starwatch.PutAnnouncementAsync(patch);
+
+                if (response.Status != RestStatus.OK)
+                    throw new RestResponseException(response);
+
+                await ctx.ReplyAsync($"{ctx.User.Mention}: Enabled announcement #{id}");
+            }
+
+            [Command("disable")]
+            [Permission("sw.announce.disable")]
+            [Description("Disables an announcement.")]
+            public async Task DisableAnnouncement(CommandContext ctx,
+                [Description("The ID of the announcement")] int id)
+            {
+                await ctx.ReplyWorkingAsync();
+
+                AnnouncementPatch patch = new AnnouncementPatch
+                {
+                    Enabled = false,
+                    Id = id
+                };
+
+                var response = await Starwatch.PutAnnouncementAsync(patch);
+
+                if (response.Status != RestStatus.OK)
+                    throw new RestResponseException(response);
+
+                await ctx.ReplyAsync($"{ctx.User.Mention}: Disabled announcement #{id}");
+            }
+
             [Command("get")]
             [Permission("sw.announcement.view")]
             [Description("Checks an announcement")]

--- a/KoalaBot/Starwatch/Entities/Announcement.cs
+++ b/KoalaBot/Starwatch/Entities/Announcement.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace KoalaBot.Starwatch.Entities
+{
+    public class Announcement
+    {
+        public string Message { get; set; }
+        public bool Enabled { get; set; }
+        public double Interval { get; set; }
+    }
+}

--- a/KoalaBot/Starwatch/Entities/AnnouncementPatch.cs
+++ b/KoalaBot/Starwatch/Entities/AnnouncementPatch.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace KoalaBot.Starwatch.Entities
+{
+    public class AnnouncementPatch
+    {
+        public string Message { get; set; }
+        public bool? Enabled { get; set; }
+        public double? Interval { get; set; }
+    }
+}

--- a/KoalaBot/Starwatch/Entities/AnnouncementPatch.cs
+++ b/KoalaBot/Starwatch/Entities/AnnouncementPatch.cs
@@ -6,6 +6,7 @@ namespace KoalaBot.Starwatch.Entities
 {
     public class AnnouncementPatch
     {
+        public int Id { get; set; }
         public string Message { get; set; }
         public bool? Enabled { get; set; }
         public double? Interval { get; set; }

--- a/KoalaBot/Starwatch/StarwatchClient.cs
+++ b/KoalaBot/Starwatch/StarwatchClient.cs
@@ -213,6 +213,16 @@ namespace KoalaBot.Starwatch
 
         public async Task<Response<object>> PostAnnouncementAsync(string message, bool enabled, double interval) => await PostRequestAsync<object>($"/announcement?message={message}&enabled={enabled}&interval={interval}");
 
+        public async Task<Response<Announcement>> PutAnnouncementAsync (AnnouncementPatch announcement)
+        {
+            if (announcement is null)
+                throw new ArgumentNullException(nameof(announcement));
+
+            return await PutRequestAsync<Announcement>($"/announcement",
+                new Dictionary<string, object> { },
+                announcement);
+        }
+
         /// <summary>
         /// Gets the statistics of the server
         /// </summary>

--- a/KoalaBot/Starwatch/StarwatchClient.cs
+++ b/KoalaBot/Starwatch/StarwatchClient.cs
@@ -205,6 +205,14 @@ namespace KoalaBot.Starwatch
 
         #endregion
 
+        public async Task<Response<Announcement>> GetAnnouncementAsync(long id) => await GetRequestAsync<Announcement>($"/announcement?id={id}");
+
+        public async Task<Response<int>> GetAnnouncementCountAsync() => await GetRequestAsync<int>($"/announcement");
+
+        public async Task<Response<object>> DeleteAnnouncementAsync(long id) => await DeleteRequestAsync<object>($"/announcement?id={id}");
+
+        public async Task<Response<object>> PostAnnouncementAsync(string message, bool enabled, double interval) => await PostRequestAsync<object>($"/announcement?message={message}&enabled={enabled}&interval={interval}");
+
         /// <summary>
         /// Gets the statistics of the server
         /// </summary>


### PR DESCRIPTION
Uses [Starwatch's new announcement route](https://github.com/Lachee/starwatch/pull/21) to update announcements.

### Commands
- **\sw announcement delete {id}**
Deletes an announcement by ID.
Aliases: ``-``, ``remove``

- **\sw announcement add {message} {enabled} {interval}**
Adds an announcement.
Alias: ``+``

- **\sw announcement enable {id}**
Enables an announcement by ID.

- **\sw announcement disable {id}**
Disables an announcement by ID.

- **\sw announcement setmessage {id} {message}**
Sets an announcement's message.
Alias: ``setmsg``

- **\sw announcement setinterval {id} {interval}**
Sets an announcement's interval in seconds.
Aliases: ``setint``, ``timer``, ``settimer``

- **\sw announcement view {id}**
Views an announcement by ID.
Alias: ``get``